### PR TITLE
fix: numpy v2 attributes

### DIFF
--- a/utils/io_utils.py
+++ b/utils/io_utils.py
@@ -8,8 +8,8 @@ import numpy as np
 
 IMG_EXT = ['.bmp', '.jpg', '.png', '.jpeg']
 
-NP_BOOL_TYPES = (np.bool_, np.bool8)
-NP_FLOAT_TYPES = (np.float_, np.float16, np.float32, np.float64)
+NP_BOOL_TYPES = (np.bool_)
+NP_FLOAT_TYPES = (np.float16, np.float32, np.float64)
 NP_INT_TYPES = (np.int_, np.int8, np.int16, np.int32, np.int64, np.uint, np.uint8, np.uint16, np.uint32, np.uint64)
 
 # https://stackoverflow.com/questions/26646362/numpy-array-is-not-json-serializable


### PR DESCRIPTION
np.bool8 and np.float_ are deprecated in current versions of numpy. This change fixes the attribute errors in mokuro.